### PR TITLE
pyproject.toml -> depend on `build123d==0.9.1` instead of `0.6` (and bump version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gfthings"
-version = "0.5.1"
+version = "0.5.2"
 description = "Paul's Gridfinity Things"
 authors = ["Paul Bone <paul@bone.id.au>"]
 license = "CC BY-NC-SA 4.0"
@@ -22,7 +22,7 @@ gfedge = "gfthings.gfedge:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-build123d = "^0.6.0"
+build123d = "^0.9.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This fixes https://github.com/PaulBone/gfthings/issues/2 by updating `gfthings` dependency on `build123d` to the latest 0.9.1 version (which comes with other benefits such as many bugfixes and also support for python 3.13 -- although support for python 3.9 was dropped).

I tested all modules gfbin, gfbase, gfedge, and gfpin and they all worked fine with the newer `build123d` version.

EDIT: FYI -- I did not update poetry.lock